### PR TITLE
Invert Console Logic to be more user friendly

### DIFF
--- a/ChromeDllInjector/ChromeDllInjector.csproj
+++ b/ChromeDllInjector/ChromeDllInjector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<OutputType>Exe</OutputType>
+	<OutputType>WinExe</OutputType>
 	<TargetFramework>net6.0-windows10.0.17763.0</TargetFramework>
 	<Nullable>enable</Nullable>
 	<Version>6.0.0.0</Version>

--- a/ChromeDllInjector/Program.cs
+++ b/ChromeDllInjector/Program.cs
@@ -17,7 +17,9 @@ namespace ChromeDllInjector {
 		static void Main(string[] _) {
 			try {
 #if !DEBUG
-				RedirectConsole();
+				RedirectOutput();
+#else
+				AttachConsole();
 #endif
 				CreateInjector();
 				LoadChromeExePaths();
@@ -61,10 +63,15 @@ namespace ChromeDllInjector {
 			}
 		}
 
-		// Init functions to make the code cleaner
-		private static void RedirectConsole() {
-			Kernel32.FreeConsole(); // Hide the console window
+		private static void AttachConsole()
+		{
+			if (!Kernel32.AttachConsole(Kernel32.ATTACH_PARENT_PROCESS)) { // If we can't attach to the parent console, create a new one
+				Kernel32.AllocConsole();
+			}
+		}
 
+		// Init functions to make the code cleaner
+		private static void RedirectOutput() {
 			StreamWriter writer;
 			Console.SetOut(writer = new StreamWriter(new FileStream(Environment.GetFolderPath(Environment.SpecialFolder.Windows) + @"\Temp\ChromePatcherInjector.log", FileMode.Append, FileAccess.Write, FileShare.Read))); // Redirect to C:\Windows\Temp\ChromePatcherInjector.log
 			writer.AutoFlush = true;


### PR DESCRIPTION
This PR inverts the ChromeDllInjector Console Logic by Creating a Console via `Kernel32.AllocConsole();` instead of Destroying the current Console session if the build is not Debug.

<h3>Why though?</h3>
When the program runs on Startup the Console is briefly seen which is unnecessary.

<h3>What's Changed?</h3>

* Release no longer calls `Kernel32.FreeConsole();`
* Debug now calls `Kernel32.AllocConsole();` 